### PR TITLE
generating random key

### DIFF
--- a/arduino/serial_only_wallet/serial_only_wallet.ino
+++ b/arduino/serial_only_wallet/serial_only_wallet.ino
@@ -1,11 +1,14 @@
 // bitcoin library
 #include <Bitcoin.h>
+#include <Hash.h>
 
 // SD card libs
 #include <SPI.h>
 #include <SD.h>
 
-// private key
+// root key (master)
+HDPrivateKey rootKey;
+// account key (m/44'/1'/0'/)
 HDPrivateKey hd;
 
 // set to false to use on mainnet
@@ -13,6 +16,41 @@ HDPrivateKey hd;
 
 void show(String msg, bool done=true){
     Serial.println(msg);
+}
+
+// uses last bit of the analogRead values
+// to generate a random byte
+byte getRandomByte(int analogInput = A0){
+    byte val = 0;
+    for(int i = 0; i < 8; i++){
+        int init = analogRead(analogInput);
+        int count = 0;
+        // waiting for analog value to change
+        while(analogRead(analogInput) == init){
+            ++count;
+        }
+        // if we've got a new value right away 
+        // use last bit of the ADC
+        if (count == 0) { 
+            val = (val << 1) | (init & 0x01);
+        } else { // if not, use last bit of count
+            val = (val << 1) | (count & 0x01);
+        }
+    }
+}
+
+HDPrivateKey getRandomKey(int analogInput = A0){
+    byte seed[64];
+    // fill seed with random bytes
+    for(int i=0; i<sizeof(seed); i++){
+        seed[i] = getRandomByte(analogInput);
+    }
+    // increase randomness by applying sha512
+    // seed -> sha512(seed)
+    sha512(seed, sizeof(seed), seed);
+    HDPrivateKey key;
+    key.fromSeed(seed, sizeof(seed), USE_TESTNET);
+    return key;
 }
 
 bool requestTransactionSignature(Transaction tx){
@@ -118,9 +156,10 @@ void load_xprv(){
         HDPrivateKey imported_hd(xprv_buf);
         if(imported_hd){ // check if parsing was successfull
             Serial.println("success: private key loaded");
+            rootKey = imported_hd;
             // we will use bip44: m/44'/coin'/0' 
             // coin = 1 for testnet, 0 for mainnet
-            hd = imported_hd.hardenedChild(44).hardenedChild(USE_TESTNET).hardenedChild(0);
+            hd = rootKey.hardenedChild(44).hardenedChild(USE_TESTNET).hardenedChild(0);
             Serial.println(hd.xpub()); // print xpub to serial
         }else{
             Serial.println("error: can't parse xprv.txt");
@@ -136,6 +175,15 @@ void get_address(char * cmd, bool change=false){
     String addr = hd.child(change).child(index).address();
     Serial.println(addr);
     show(addr);
+}
+
+void generate_key(){
+    show("Generating new key...");
+    rootKey = getRandomKey();
+    hd = rootKey.hardenedChild(44).hardenedChild(USE_TESTNET).hardenedChild(0);
+    show(hd);
+    Serial.println("success: random key generated");
+    Serial.println(hd.xpub());
 }
 
 void parseCommand(char * cmd){
@@ -157,6 +205,10 @@ void parseCommand(char * cmd){
     }
     if(memcmp(cmd, "changeaddr", strlen("changeaddr"))==0){
         get_address(cmd + strlen("changeaddr"), true);
+        return;
+    }
+    if(memcmp(cmd, "generate_key", strlen("generate_key"))==0){
+        generate_key();
         return;
     }
     Serial.println("error: unknown command");


### PR DESCRIPTION
Using `generate_key` command we can now generate a random HD key.
As a source of randomness, we use noise on the analog inputs (ADCs) of the arduino - by default we use analog input A0, but it can be changed (optional argument).
We can't save this random key right now, this should be the next step - implementing `save_xprv <file>` and `load_xprv <file>`.